### PR TITLE
Adding TCK / ftest modules.

### DIFF
--- a/core/src/main/java/org/jboss/pnc/causeway/boot/CausewayBootOptions.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/boot/CausewayBootOptions.java
@@ -16,6 +16,8 @@
 package org.jboss.pnc.causeway.boot;
 
 import org.commonjava.propulsor.boot.BootOptions;
+import org.commonjava.propulsor.deploy.undertow.UndertowBootOptions;
+import org.kohsuke.args4j.Option;
 
 import java.io.File;
 
@@ -24,10 +26,26 @@ import java.io.File;
  */
 public class CausewayBootOptions
         extends BootOptions
+        implements UndertowBootOptions
 {
     public static final String CAUSEWAY_CONFIG_SYSPROP = "causeway.config";
 
     private static final String CAUSEWAY_HOME_SYSPROP = "causeway.home";
+
+    public static final String DEFAULT_CONTEXT_PATH = "/";
+
+    public static final int DEFAULT_PORT = 8080;
+
+    public static final String DEFAULT_BIND = "0.0.0.0";
+
+    @Option( name = "-C", aliases = { "--context" }, usage = "Specify the context path (default: '/')")
+    private String contextPath;
+
+    @Option(name = "-p", aliases = { "--port" }, usage = "Specify the HTTP port (default: 8080)")
+    private Integer port;
+
+    @Option(name = "-b", aliases = { "--bind" }, usage = "Specify the network interface to bind to (default: all or '0.0.0.0')")
+    private String bind;
 
     @Override
     public String getApplicationName()
@@ -57,5 +75,44 @@ public class CausewayBootOptions
     {
         String config = getSpecifiedConfig();
         return config == null ? new File( getHomeDir(), "etc/main.conf" ).getPath() : config;
+    }
+
+    @Override
+    public String getContextPath()
+    {
+        return contextPath == null ? DEFAULT_CONTEXT_PATH : contextPath;
+    }
+
+    @Override
+    public String getDeploymentName()
+    {
+        return getApplicationName();
+    }
+
+    @Override
+    public int getPort()
+    {
+        return port == null ? DEFAULT_PORT : port;
+    }
+
+    @Override
+    public String getBind()
+    {
+        return bind == null ? DEFAULT_BIND : bind;
+    }
+
+    public void setContextPath( String contextPath )
+    {
+        this.contextPath = contextPath;
+    }
+
+    public void setPort( int port )
+    {
+        this.port = port;
+    }
+
+    public void setBind( String bind )
+    {
+        this.bind = bind;
     }
 }

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -24,33 +24,29 @@
     <version>0.1-SNAPSHOT</version>
   </parent>
   
-  <artifactId>causeway-core</artifactId>
-  <name>Causeway :: Core Implementation</name>
+  <artifactId>causeway-ftest</artifactId>
+  <name>Causeway :: Functional Tests</name>
   
   <dependencies>
+    <dependency>
+      <groupId>org.jboss.pnc.causeway</groupId>
+      <artifactId>causeway-tck</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jboss.pnc.causeway</groupId>
       <artifactId>causeway-model-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.pnc.causeway</groupId>
+      <artifactId>causeway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc.causeway</groupId>
+      <artifactId>causeway-rest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.util</groupId>
       <artifactId>jhttpc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.propulsor</groupId>
-      <artifactId>propulsor-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.propulsor</groupId>
-      <artifactId>propulsor-undertow</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
-      <artifactId>configuration-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
-      <artifactId>configuration-dotconf</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -71,60 +67,38 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
-      <groupId>args4j</groupId>
-      <artifactId>args4j</artifactId>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
     </dependency>
   </dependencies>
-  
-<!--   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <groupId>ru.concerteza.buildnumber</groupId>
-        <artifactId>maven-jgit-buildnumber-plugin</artifactId>
-        <version>1.2.9</version>
-        <executions>
-          <execution>
-            <id>git-buildnumber</id>
-            <goals>
-              <goal>extract-buildnumber</goal>
-            </goals>
-            <phase>initialize</phase>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
+              <forkCount>${test-forkCount}</forkCount>
+              <reuseForks>false</reuseForks>
+              <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
+              <dependenciesToScan>
+                <dependency>${project.groupId}:causeway-tck</dependency>
+              </dependenciesToScan> 
             </configuration>
-          </execution>
-        </executions>
-      </plugin> 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.1</version>
-        <executions>
-          <execution>
-            <id>buildnumbers</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <configuration>
-              <timestampFormat>{0,date,yyyy-MM-dd HH:mm Z}</timestampFormat>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
- -->
 </project>

--- a/ftest/src/test/java/org/jboss/pnc/causeway/test/LocalTestDriver.java
+++ b/ftest/src/test/java/org/jboss/pnc/causeway/test/LocalTestDriver.java
@@ -1,0 +1,160 @@
+package org.jboss.pnc.causeway.test;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.commonjava.propulsor.boot.BootStatus;
+import org.commonjava.propulsor.boot.Booter;
+import org.commonjava.util.jhttpc.HttpFactory;
+import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
+import org.commonjava.util.jhttpc.auth.PasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
+import org.commonjava.util.jhttpc.util.UrlUtils;
+import org.jboss.pnc.causeway.boot.CausewayBootOptions;
+import org.jboss.pnc.causeway.test.spi.CausewayDriver;
+import org.jboss.pnc.causeway.test.util.HttpCommands;
+import org.junit.AfterClass;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by jdcasey on 2/11/16.
+ */
+public class LocalTestDriver
+        implements CausewayDriver
+{
+    private CausewayBootOptions options;
+
+    private BootStatus bootStatus;
+
+    private Booter booter;
+
+    private PasswordManager passwordManager;
+
+    private HttpFactory httpFactory;
+
+    private SiteConfig siteConfig;
+
+    private TemporaryFolder temp = new TemporaryFolder();
+
+    private File configDir;
+
+    @Override
+    public void start()
+            throws Exception
+    {
+        temp.create();
+
+        configDir = temp.newFolder( "local-causeway-etc" );
+
+        File mainConf = new File( configDir, "etc/main.conf" );
+        mainConf.getParentFile().mkdirs();
+
+        FileUtils.write( mainConf, "koji.url=https://koji.myco.com/kojihub\n"
+                + "pncl.url=https://pncl.myco.com/\n"
+                + "koji.client.pem.password = mypassword" );
+
+        System.out.println(
+                "Wrote configuration: " + mainConf + " with configuration:\n\n" + FileUtils.readFileToString(
+                        mainConf ) );
+
+        options = new CausewayBootOptions();
+        options.setPort( -1 );
+        options.setHomeDir( configDir.getAbsolutePath() );
+
+        booter = new Booter();
+        bootStatus = booter.start( options );
+
+        if ( bootStatus == null )
+        {
+            fail( "No boot status" );
+        }
+
+        Throwable t = bootStatus.getError();
+        if ( t != null )
+        {
+            throw new RuntimeException( "Failed to start Causeway test server.", t );
+        }
+
+        assertThat( bootStatus.isSuccess(), equalTo( true ) );
+
+        passwordManager = new MemoryPasswordManager();
+        siteConfig = new SiteConfigBuilder( "local-test", formatUrl().toString() ).build();
+        httpFactory = new HttpFactory( passwordManager );
+    }
+
+    @Override
+    public void stop()
+            throws Exception
+    {
+        if ( booter != null && bootStatus != null && bootStatus.isSuccess() )
+        {
+            booter.stop();
+        }
+
+        temp.delete();
+    }
+
+    private void checkStarted()
+    {
+        if ( booter == null || bootStatus == null || !bootStatus.isSuccess() )
+        {
+            throw new RuntimeException( "Cannot execute; Causeway test server is not running." );
+        }
+    }
+
+    @Override
+    public int getPort()
+    {
+        checkStarted();
+        return options.getPort();
+    }
+
+    @Override
+    public String formatUrl( String... pathParts )
+            throws MalformedURLException
+    {
+        checkStarted();
+        return UrlUtils.buildUrl( String.format( "http://localhost:%d", getPort() ), pathParts );
+    }
+
+    @Override
+    public HttpFactory getHttpFactory()
+            throws Exception
+    {
+        return httpFactory;
+    }
+
+    @Override
+    public SiteConfig getSiteConfig()
+            throws Exception
+    {
+        return siteConfig;
+    }
+
+    @Override
+    public PasswordManager getPasswordManager()
+            throws Exception
+    {
+        return passwordManager;
+    }
+
+    @Override
+    public void withNewHttpClient( HttpCommands commands )
+            throws Exception
+    {
+        try (CloseableHttpClient client = httpFactory.createClient( siteConfig ))
+        {
+            commands.execute( this, client ).throwError();
+        }
+    }
+}

--- a/ftest/src/test/resources/META-INF/services/org.jboss.pnc.causeway.test.spi.CausewayDriver
+++ b/ftest/src/test/resources/META-INF/services/org.jboss.pnc.causeway.test.spi.CausewayDriver
@@ -1,0 +1,1 @@
+org.jboss.pnc.causeway.test.LocalTestDriver

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
     <module>core</module>
     <module>rest</module>
     <module>launcher</module>
+    <module>tck</module>
+    <module>ftest</module>
   </modules>
 
   <dependencyManagement>
@@ -85,6 +87,12 @@
         <groupId>org.jboss.pnc.causeway</groupId>
         <artifactId>causeway-launcher</artifactId>
         <version>0.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.pnc.causeway</groupId>
+        <artifactId>causeway-tck</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -147,10 +155,6 @@
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -24,8 +24,8 @@
     <version>0.1-SNAPSHOT</version>
   </parent>
   
-  <artifactId>causeway-core</artifactId>
-  <name>Causeway :: Core Implementation</name>
+  <artifactId>causeway-tck</artifactId>
+  <name>Causeway :: TCK</name>
   
   <dependencies>
     <dependency>
@@ -33,24 +33,16 @@
       <artifactId>causeway-model-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.pnc.causeway</groupId>
+      <artifactId>causeway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc.causeway</groupId>
+      <artifactId>causeway-rest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.util</groupId>
       <artifactId>jhttpc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.propulsor</groupId>
-      <artifactId>propulsor-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.propulsor</groupId>
-      <artifactId>propulsor-undertow</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
-      <artifactId>configuration-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
-      <artifactId>configuration-dotconf</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -71,60 +63,20 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
-      <groupId>args4j</groupId>
-      <artifactId>args4j</artifactId>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
     </dependency>
   </dependencies>
-  
-<!--   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <groupId>ru.concerteza.buildnumber</groupId>
-        <artifactId>maven-jgit-buildnumber-plugin</artifactId>
-        <version>1.2.9</version>
-        <executions>
-          <execution>
-            <id>git-buildnumber</id>
-            <goals>
-              <goal>extract-buildnumber</goal>
-            </goals>
-            <phase>initialize</phase>
-            <configuration>
-              <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin> 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.1</version>
-        <executions>
-          <execution>
-            <id>buildnumbers</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <configuration>
-              <timestampFormat>{0,date,yyyy-MM-dd HH:mm Z}</timestampFormat>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
- -->
 </project>

--- a/tck/src/main/java/org/jboss/pnc/causeway/test/AbstractTest.java
+++ b/tck/src/main/java/org/jboss/pnc/causeway/test/AbstractTest.java
@@ -1,0 +1,76 @@
+package org.jboss.pnc.causeway.test;
+
+import org.commonjava.util.jhttpc.HttpFactory;
+import org.commonjava.util.jhttpc.auth.PasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.jboss.pnc.causeway.test.spi.CausewayDriver;
+import org.jboss.pnc.causeway.test.util.HttpCommands;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ServiceLoader;
+
+/**
+ * Created by jdcasey on 2/11/16.
+ */
+public class AbstractTest
+{
+    private static CausewayDriver driver;
+
+    @BeforeClass
+    public static void startup()
+            throws Exception
+    {
+        ServiceLoader<CausewayDriver> loader = ServiceLoader.load( CausewayDriver.class );
+        driver = loader.iterator().next();
+
+        driver.start();
+    }
+
+    @AfterClass
+    public static void shutdown()
+            throws Exception
+    {
+        if ( driver != null )
+        {
+            driver.stop();
+        }
+    }
+
+    protected int getPort()
+    {
+        return driver.getPort();
+    }
+
+    protected String formatUrl( String... pathParts )
+            throws MalformedURLException
+    {
+        return driver.formatUrl( pathParts );
+    }
+
+    protected HttpFactory getHttpFactory()
+            throws Exception
+    {
+        return driver.getHttpFactory();
+    }
+
+    protected SiteConfig getSiteConfig()
+            throws Exception
+    {
+        return driver.getSiteConfig();
+    }
+
+    protected PasswordManager getPasswordManager()
+            throws Exception
+    {
+        return driver.getPasswordManager();
+    }
+
+    protected void withNewHttpClient( HttpCommands commands )
+            throws Exception
+    {
+        driver.withNewHttpClient( commands );
+    }
+}

--- a/tck/src/main/java/org/jboss/pnc/causeway/test/PncImportResourceTest.java
+++ b/tck/src/main/java/org/jboss/pnc/causeway/test/PncImportResourceTest.java
@@ -1,0 +1,50 @@
+package org.jboss.pnc.causeway.test;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.jboss.pnc.causeway.test.util.HttpCommandResult;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by jdcasey on 2/11/16.
+ */
+public class PncImportResourceTest
+    extends AbstractTest
+{
+    @Test
+    public void checkTestMethod()
+            throws Exception
+    {
+        withNewHttpClient( (driver, client)->{
+            String var = Long.toHexString( new Date().getTime() );
+
+            try
+            {
+                String url = formatUrl( "/import/test", var );
+                HttpGet request = new HttpGet( url );
+
+                HttpResponse response = client.execute( request );
+                assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+
+                String result = IOUtils.toString( response.getEntity().getContent() ).trim();
+                assertThat( result, equalTo( var ) );
+            }
+            catch ( Exception e )
+            {
+                return new HttpCommandResult( e );
+            }
+
+            return new HttpCommandResult();
+        });
+    }
+}

--- a/tck/src/main/java/org/jboss/pnc/causeway/test/spi/CausewayDriver.java
+++ b/tck/src/main/java/org/jboss/pnc/causeway/test/spi/CausewayDriver.java
@@ -1,0 +1,31 @@
+package org.jboss.pnc.causeway.test.spi;
+
+import org.commonjava.util.jhttpc.HttpFactory;
+import org.commonjava.util.jhttpc.auth.PasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.jboss.pnc.causeway.test.util.HttpCommands;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Created by jdcasey on 2/11/16.
+ */
+public interface CausewayDriver
+{
+    void start() throws Exception;
+
+    void stop() throws Exception;
+
+    int getPort();
+
+    String formatUrl( String...pathParts ) throws MalformedURLException;
+
+    HttpFactory getHttpFactory() throws Exception;
+
+    SiteConfig getSiteConfig() throws Exception;
+
+    PasswordManager getPasswordManager() throws Exception;
+
+    void withNewHttpClient( HttpCommands commands ) throws Exception;
+}

--- a/tck/src/main/java/org/jboss/pnc/causeway/test/util/HttpCommandResult.java
+++ b/tck/src/main/java/org/jboss/pnc/causeway/test/util/HttpCommandResult.java
@@ -1,0 +1,27 @@
+package org.jboss.pnc.causeway.test.util;
+
+/**
+ * Created by jdcasey on 2/11/16.
+ */
+public class HttpCommandResult
+{
+    private Exception error;
+
+    public HttpCommandResult()
+    {
+    }
+
+    public HttpCommandResult( Exception error )
+    {
+        this.error = error;
+    }
+
+    public void throwError()
+            throws Exception
+    {
+        if ( error != null )
+        {
+            throw error;
+        }
+    }
+}

--- a/tck/src/main/java/org/jboss/pnc/causeway/test/util/HttpCommands.java
+++ b/tck/src/main/java/org/jboss/pnc/causeway/test/util/HttpCommands.java
@@ -1,0 +1,12 @@
+package org.jboss.pnc.causeway.test.util;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.jboss.pnc.causeway.test.spi.CausewayDriver;
+
+/**
+ * Created by jdcasey on 2/11/16.
+ */
+public interface HttpCommands
+{
+    HttpCommandResult execute( CausewayDriver driver, CloseableHttpClient client );
+}


### PR DESCRIPTION
TCK is meant to be runnable from many different contexts, and ftests uses a local driver that embeds the causeway server.