### PR TITLE
[v1.4][NCL-4382] Handle NPE while capturing import errors

### DIFF
--- a/core/src/main/java/org/jboss/pnc/causeway/brewclient/BrewClientImpl.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/brewclient/BrewClientImpl.java
@@ -212,27 +212,32 @@ public class BrewClientImpl implements BrewClient {
 
     private List<ArtifactImportError> getImportErrors(KojiImportResult result, ImportFileGenerator importFiles) {
         List<ArtifactImportError> importErrors = new ArrayList<>();
-        Map<String, KojijiErrorInfo> kojiErrors = result == null ? null : result.getUploadErrors();
-        if (kojiErrors != null) {
-            for (Map.Entry<String, KojijiErrorInfo> e : kojiErrors.entrySet()) {
-                ArtifactImportError importError = ArtifactImportError.builder()
-                        .artifactId(importFiles.getId(e.getKey()))
-                        .errorMessage(e.getValue().getError().getMessage())
-                        .build();
-                importErrors.add(importError);
-                logger.log(Level.WARNING, "Failed to import.", e.getValue());
+
+        try {
+            Map<String, KojijiErrorInfo> kojiErrors = result == null ? null : result.getUploadErrors();
+            if (kojiErrors != null) {
+                for (Map.Entry<String, KojijiErrorInfo> e : kojiErrors.entrySet()) {
+                    ArtifactImportError importError = ArtifactImportError.builder()
+                            .artifactId(importFiles.getId(e.getKey()))
+                            .errorMessage(e.getValue().getError().getMessage())
+                            .build();
+                    importErrors.add(importError);
+                    logger.log(Level.WARNING, "Failed to import.", e.getValue());
+                }
             }
-        }
-        Map<Integer, String> importerErrors = importFiles.getErrors();
-        if (!importerErrors.isEmpty()) {
-            for (Map.Entry<Integer, String> e : importerErrors.entrySet()) {
-                ArtifactImportError importError = ArtifactImportError.builder()
-                        .artifactId(e.getKey())
-                        .errorMessage(e.getValue())
-                        .build();
-                importErrors.add(importError);
-                logger.log(Level.WARNING, "Failed to import: {0}", e.getValue());
+            Map<Integer, String> importerErrors = importFiles.getErrors();
+            if (!importerErrors.isEmpty()) {
+                for (Map.Entry<Integer, String> e : importerErrors.entrySet()) {
+                    ArtifactImportError importError = ArtifactImportError.builder()
+                            .artifactId(e.getKey())
+                            .errorMessage(e.getValue())
+                            .build();
+                    importErrors.add(importError);
+                    logger.log(Level.WARNING, "Failed to import: {0}", e.getValue());
+                }
             }
+        } catch (Exception exception) {
+            logger.log(Level.SEVERE, "Couldn't capture import errors", exception);
         }
         return importErrors;
     }


### PR DESCRIPTION
This commit doesn't fix the NPE thrown sometimes while capturing import
errors.

From the stacktrace, the NPE is thrown in `BrewClientImpl.java`, line
219, which corresponds to:

```java
for (Map.Entry<String, KojijiErrorInfo> e : kojiErrors.entrySet()) {
    ArtifactImportError importError = ArtifactImportError.builder()
            .artifactId(importFiles.getId(e.getKey()))    // line 219
            .errorMessage(e.getValue().getError().getMessage())
            .build();
    importErrors.add(importError);
    logger.log(Level.WARNING, "Failed to import.", e.getValue());
}
```

`e` won't be null, `e.getKey()` might return null but that shouldn't
affect `importFiles.getId`. `importFiles` can't be null when tracing
where that object was created.

Instead of trying to figure this out, this commit wraps the code block
into a try/catch clause to catch any exception and return an empty koji
error list.

While this commit doesn't fix the original problem, it allows Causeway
to better handle such events.

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
