### PR TITLE
[NCL-4676] Revert to use OpenJDK 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   <properties>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <projectEmail>jbrazdil@redhat.com</projectEmail>
-    <javaVersion>11</javaVersion>
+    <javaVersion>1.8</javaVersion>
     <jhttpcVersion>1.6</jhttpcVersion>
     <configVersion>0.8</configVersion>
     <mockitoVersion>1.10.19</mockitoVersion>


### PR DESCRIPTION
This is done to workaround a bug found in EAP 7.2.3 with JDK 11
(https://issues.jboss.org/browse/WFCORE-4674)

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
