### PR TITLE
[NCL-6651] Improve sources input stream handling

### DIFF
--- a/core/src/main/java/org/jboss/pnc/causeway/brewclient/BuildTranslatorImpl.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/brewclient/BuildTranslatorImpl.java
@@ -370,18 +370,20 @@ public class BuildTranslatorImpl implements BuildTranslator {
     public RenamedSources getSources(Build build) throws CausewayException {
         try {
             URL sourcesUrl = new URL(build.getSourcesURL());
-            if (build.getClass().equals(MavenBuild.class)) {
-                MavenBuild mavenBuild = (MavenBuild) build;
-                return renamer.repackMaven(
-                        sourcesUrl.openStream(),
-                        mavenBuild.getGroupId(),
-                        mavenBuild.getArtifactId(),
-                        mavenBuild.getVersion());
-            } else if (build.getClass().equals(NpmBuild.class)) {
-                NpmBuild npmBuild = (NpmBuild) build;
-                return renamer.repackNPM(sourcesUrl.openStream(), npmBuild.getName(), npmBuild.getVersion());
-            } else {
-                throw new IllegalArgumentException("Unsupported build type " + build.getClass());
+            try (InputStream input = sourcesUrl.openStream()) {
+                if (build.getClass().equals(MavenBuild.class)) {
+                    MavenBuild mavenBuild = (MavenBuild) build;
+                    return renamer.repackMaven(
+                            input,
+                            mavenBuild.getGroupId(),
+                            mavenBuild.getArtifactId(),
+                            mavenBuild.getVersion());
+                } else if (build.getClass().equals(NpmBuild.class)) {
+                    NpmBuild npmBuild = (NpmBuild) build;
+                    return renamer.repackNPM(input, npmBuild.getName(), npmBuild.getVersion());
+                } else {
+                    throw new IllegalArgumentException("Unsupported build type " + build.getClass());
+                }
             }
         } catch (IOException ex) {
             throw new CausewayException("Failed to read sources url: " + ex.getMessage(), ex);

--- a/core/src/main/java/org/jboss/pnc/causeway/pncclient/PncClientImpl.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/pncclient/PncClientImpl.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc. (jbrazdil@redhat.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -121,8 +121,14 @@ public class PncClientImpl implements PncClient {
 
     @Override
     public InputStream getSources(String id) throws CausewayException {
-        try (Response response = buildClient.getInternalScmArchiveLink(id)) {
-            return response.readEntity(InputStream.class);
+        try {
+            Response response = buildClient.getInternalScmArchiveLink(id);
+            try {
+                return response.readEntity(InputStream.class);
+            } catch (RuntimeException e) {
+                response.close();
+                throw new CausewayException("Can not read sources of build " + id + ": " + e.getMessage(), e);
+            }
         } catch (RemoteResourceException e) {
             throw new CausewayException(
                     "Can not read sources of build " + id + " because PNC responded with an error - response "


### PR DESCRIPTION
The PNC client prematuerly closed the response while the input stream
was not read yet. Also made sure we close input streams when an error
occures.

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
