### PR TITLE
Bump jboss parent version to 39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>36</version>
+    <version>39</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
That should bring in updated javadoc plugin that'll work with java 11

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
