### PR TITLE
Don't use internal API for Java 11

### DIFF
--- a/core/src/main/java/org/jboss/pnc/causeway/ErrorMessages.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/ErrorMessages.java
@@ -4,7 +4,6 @@ import com.redhat.red.build.koji.KojiClientException;
 import com.redhat.red.build.koji.KojijiErrorInfo;
 import com.redhat.red.build.koji.model.json.KojiJsonConstants;
 import com.redhat.red.build.koji.model.json.VerificationException;
-import jdk.internal.joptsimple.internal.Strings;
 import org.jboss.pnc.api.causeway.dto.push.Build;
 import org.jboss.pnc.causeway.brewclient.BrewClientImpl;
 import org.jboss.pnc.causeway.brewclient.BuildTranslatorImpl;
@@ -272,7 +271,7 @@ public class ErrorMessages {
      * {@value CONFIG_IS_NOT_COMPLETE}
      */
     public static String configIsNotComplete(List<String> validationErrors) {
-        String formattedValidationErrors = Strings.join(validationErrors, "\n");
+        String formattedValidationErrors = String.join("\n", validationErrors);
         return MessageFormat.format(CONFIG_IS_NOT_COMPLETE, formattedValidationErrors);
     }
 


### PR DESCRIPTION
We aren't able to release Causeway because of the use of internal API which is not really allowed in java 11. This commit is used to remove the use of the internal API.

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
