### PR TITLE
[NCLSUP-816] Use single thread to workaround kojiji issues

### DIFF
--- a/core/src/main/java/org/jboss/pnc/causeway/inject/CausewayProducer.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/inject/CausewayProducer.java
@@ -22,14 +22,14 @@ import org.jboss.pnc.causeway.ErrorMessages;
 import org.jboss.pnc.causeway.config.CausewayConfig;
 
 import javax.annotation.PreDestroy;
-import javax.annotation.Resource;
-import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import java.io.Closeable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import com.redhat.red.build.koji.KojiClient;
 import com.redhat.red.build.koji.KojiClientException;
@@ -44,8 +44,7 @@ public class CausewayProducer implements Closeable {
 
     private final CausewayConfig config;
 
-    @Resource
-    private ManagedExecutorService executorService;
+    private ExecutorService executorService;
 
     private KojiClient koji;
 
@@ -55,6 +54,7 @@ public class CausewayProducer implements Closeable {
     public CausewayProducer(CausewayConfig config) {
         this.config = config;
         passwords.bind(config.getKojiClientCertificatePassword(), CausewayConfig.KOJI_SITE_ID, PasswordType.KEY);
+        executorService = Executors.newSingleThreadExecutor();
     }
 
     private synchronized void setupKoji(PasswordManager passwords) {


### PR DESCRIPTION
Kojiji currently is not doing concurrent uploads to Koji in a kosher way. To workaround this, we'll just provide a single thread in the executor service to force 1 upload at a time.

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
