### PR TITLE
[NCL-8055] Add service account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ PNC tracks metrics of JVM and its internals via Dropwizard Metrics. The metrics 
 If the `metrics_graphite_interval` variable (interval specified in seconds) is not specified, we'll use the default value of 60 seconds to report data to Graphite.
 
 The graphite reporter is configured to report rates per second and durations in terms of milliseconds.
+
+## OIDC Client Support
+We need to setup an OIDC Client to send back callback information. This is done by defining in the main.conf the following values:
+
+- `oidc-client.url`: Base URL of the Keycloak server
+- `oidc-client.realm`: Realm used with Keycloak
+- `oidc-client.client-id`: the client id name
+- `oidc-client.secret-file`: the location of the file that contains the secret
+
+Only client credentials flow is supported for now.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,11 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-authz-client</artifactId>
+    </dependency>
+
 
     <dependency>
       <groupId>junit</groupId>

--- a/core/src/main/java/org/jboss/pnc/causeway/authentication/KeycloakClient.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/authentication/KeycloakClient.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jbrazdil@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.causeway.authentication;
+
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.pnc.causeway.config.CausewayConfig;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.Configuration;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Helper object to obtain a fresh access token from Keycloak
+ */
+@ApplicationScoped
+public class KeycloakClient {
+
+    @Inject
+    CausewayConfig config;
+
+    /**
+     * Get a fresh access token from the OIDC server
+     * 
+     * @return access token
+     * @throws KeycloakClientException if there is an issue with the configuration
+     */
+    public String getAccessToken() throws KeycloakClientException {
+        try {
+            final Configuration configuration = new Configuration(
+                    config.getOidcClientUrl(),
+                    config.getOidcClientRealm(),
+                    config.getOidcClientClientId(),
+                    Collections.singletonMap("secret", config.getOidcClientSecret()),
+                    HttpClients.createDefault());
+
+            return AuthzClient.create(configuration).obtainAccessToken().getToken();
+        } catch (IOException e) {
+            throw new KeycloakClientException("Exception trying to obtain an auth token", e);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/causeway/authentication/KeycloakClientException.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/authentication/KeycloakClientException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jbrazdil@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.causeway.authentication;
+
+import org.jboss.pnc.causeway.CausewayException;
+
+public class KeycloakClientException extends CausewayException {
+
+    public KeycloakClientException(String format, Throwable cause, Object... params) {
+        super(format, cause, params);
+    }
+
+    public KeycloakClientException(String format, Object... params) {
+        super(format, params);
+    }
+
+}

--- a/core/src/main/java/org/jboss/pnc/causeway/config/CausewayConfig.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/config/CausewayConfig.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +54,11 @@ public class CausewayConfig {
     public static final String PNCL_URL_OPTION = "pncl.url";
 
     public static final String PNCL_BUILDS_URL_OPTION = "pncl.builds.url";
+
+    public static final String OIDC_CLIENT_URL = "oidc-client.url";
+    public static final String OIDC_CLIENT_REALM = "oidc-client.realm";
+    public static final String OIDC_CLIENT_CLIENT_ID = "oidc-client.client-id";
+    public static final String OIDC_CLIENT_SECRET_FILE = "oidc-client.secret-file";
 
     public static final String PNC_SYSTEM_VERSION = "pnc.system.version";
 
@@ -121,6 +127,19 @@ public class CausewayConfig {
     private Set<String> ignoredTools;
 
     private Integer pnclTimeout;
+
+    private String oidcClientUrl;
+
+    private String oidcClientRealm;
+
+    private String oidcClientClientId;
+
+    private String oidcClientSecretFile;
+
+    /**
+     * Cache the content of the oidcClientSecretFile
+     */
+    private String cachedSecretFileContent;
 
     private SiteConfig kojiSiteConfig;
 
@@ -371,6 +390,51 @@ public class CausewayConfig {
     @ConfigName("pnc.tools.ignored")
     public void setIgnoredTools(String ignoredTools) {
         this.ignoredTools = ignoredTools == null ? null : new HashSet<>(Arrays.asList(ignoredTools.split(",")));
+    }
+
+    public String getOidcClientUrl() {
+        return oidcClientUrl;
+    }
+
+    @ConfigName(CausewayConfig.OIDC_CLIENT_URL)
+    public void setOidcClientUrl(String clientUrl) {
+        this.oidcClientUrl = clientUrl;
+    }
+
+    public String getOidcClientRealm() {
+        return oidcClientRealm;
+    }
+
+    @ConfigName(CausewayConfig.OIDC_CLIENT_REALM)
+    public void setOidcClientRealm(String clientRealm) {
+        this.oidcClientRealm = clientRealm;
+    }
+
+    public String getOidcClientClientId() {
+        return oidcClientClientId;
+    }
+
+    @ConfigName(CausewayConfig.OIDC_CLIENT_CLIENT_ID)
+    public void setOidcClientClientId(String clientId) {
+        this.oidcClientClientId = clientId;
+    }
+
+    public String getOidcClientSecretFile() {
+        return oidcClientSecretFile;
+    }
+
+    @ConfigName(CausewayConfig.OIDC_CLIENT_SECRET_FILE)
+    public void setOidcClientSecretFile(String secretFile) {
+        this.oidcClientSecretFile = secretFile;
+    }
+
+    public String getOidcClientSecret() throws IOException {
+        if (cachedSecretFileContent == null) {
+            List<String> lines = Files.readAllLines(Paths.get(oidcClientSecretFile));
+            cachedSecretFileContent = String.join("\n", lines).trim();
+        }
+
+        return cachedSecretFileContent;
     }
 
     public List<String> getValidationErrors() {

--- a/core/src/main/java/org/jboss/pnc/causeway/ctl/ImportControllerImpl.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/ctl/ImportControllerImpl.java
@@ -18,12 +18,15 @@ import org.jboss.pnc.api.causeway.dto.push.Build;
 import org.jboss.pnc.api.causeway.dto.push.BuiltArtifact;
 import org.jboss.pnc.api.causeway.dto.push.Logfile;
 import org.jboss.pnc.api.causeway.dto.untag.TaggedBuild;
+import org.jboss.pnc.api.constants.HttpHeaders;
 import org.jboss.pnc.api.constants.MDCHeaderKeys;
 import org.jboss.pnc.api.constants.MDCKeys;
 import org.jboss.pnc.api.dto.Request;
 import org.jboss.pnc.causeway.CausewayException;
 import org.jboss.pnc.causeway.CausewayFailure;
 import org.jboss.pnc.causeway.ErrorMessages;
+import org.jboss.pnc.causeway.authentication.KeycloakClient;
+import org.jboss.pnc.causeway.authentication.KeycloakClientException;
 import org.jboss.pnc.causeway.brewclient.BrewClient;
 import org.jboss.pnc.causeway.brewclient.BuildTranslator;
 import org.jboss.pnc.causeway.brewclient.ImportFileGenerator;
@@ -99,6 +102,9 @@ public class ImportControllerImpl implements ImportController {
 
     @Inject
     private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private KeycloakClient keycloakClient;
 
     @Inject
     public ImportControllerImpl() {
@@ -340,6 +346,12 @@ public class ImportControllerImpl implements ImportController {
         ResteasyWebTarget target = restClient.target(callback.getUri());
         Invocation.Builder request = target.request(MediaType.APPLICATION_JSON);
         callback.getHeaders().forEach(h -> request.header(h.getName(), h.getValue()));
+
+        try {
+            request.header(HttpHeaders.AUTHORIZATION_STRING, "Bearer " + keycloakClient.getAccessToken());
+        } catch (KeycloakClientException e) {
+            log.error("Couldn't obtain the access token from the OIDC server", e);
+        }
 
         // Add OTEL headers from MDC context
         addOtelMDCHeaders(request);

--- a/core/src/test/java/org/jboss/pnc/causeway/ctl/ImportControllerTest.java
+++ b/core/src/test/java/org/jboss/pnc/causeway/ctl/ImportControllerTest.java
@@ -34,6 +34,7 @@ import org.jboss.pnc.api.causeway.dto.push.NpmBuiltArtifact;
 import org.jboss.pnc.api.dto.Request;
 import org.jboss.pnc.causeway.CausewayException;
 import org.jboss.pnc.causeway.CausewayFailure;
+import org.jboss.pnc.causeway.authentication.KeycloakClient;
 import org.jboss.pnc.causeway.brewclient.BrewClient;
 import org.jboss.pnc.causeway.brewclient.BuildTranslatorImpl;
 import org.jboss.pnc.causeway.brewclient.SpecialImportFileGenerator;
@@ -116,6 +117,9 @@ public class ImportControllerTest {
     @Mock
     public MetricRegistry metricRegistry;
 
+    @Mock
+    public KeycloakClient keycloakClient;
+
     @InjectMocks
     private ImportControllerImpl importController;
 
@@ -133,6 +137,8 @@ public class ImportControllerTest {
         Histogram histogram = mock(Histogram.class);
         when(metricRegistry.register(anyString(), any(Histogram.class))).thenReturn(histogram);
         when(metricRegistry.histogram(anyString())).thenReturn(histogram);
+
+        when(keycloakClient.getAccessToken()).thenReturn("hahaha");
 
         mapper.registerSubtypes(MavenBuild.class, NpmBuild.class, MavenBuiltArtifact.class, NpmBuiltArtifact.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,12 @@
         <version>${version.com.redhat.resilience.otel}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-authz-client</artifactId>
+        <version>19.0.1</version>
+      </dependency>
+
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
The service account is needed to send back callback data. We cannot assume anymore that the caller will or should include the 'Authorization' header for the callback because the token value of the header will expire after only 5 minutes.

Instead, we need to obtain our own access token.

To be able to use the service account, the following values need to be defined in the main.conf file:

- `oidc-client.url`: Base URL of the Keycloak server
- `oidc-client.realm`: Realm used with Keycloak
- `oidc-client.client-id`: the client id name
- `oidc-client.secret-file`: the location of the file that contains the secret

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
