### PR TITLE
Add support for Rex style of callback for milestone import

### DIFF
--- a/core/src/main/java/org/jboss/pnc/causeway/ctl/PncImportController.java
+++ b/core/src/main/java/org/jboss/pnc/causeway/ctl/PncImportController.java
@@ -24,5 +24,11 @@ import org.jboss.pnc.api.dto.Request;
 @Deprecated
 public interface PncImportController {
 
-    public void importMilestone(int milestoneId, Request callback, String callbackId, String username);
+    public void importMilestone(
+            int milestoneId,
+            Request positiveCallback,
+            Request negativeCallback,
+            Request callback,
+            String callbackId,
+            String username);
 }

--- a/core/src/test/java/org/jboss/pnc/causeway/ctl/PncImportControllerTest.java
+++ b/core/src/test/java/org/jboss/pnc/causeway/ctl/PncImportControllerTest.java
@@ -98,6 +98,10 @@ public class PncImportControllerTest {
             .asList(new Request.Header("header1", "value1"), new Request.Header("header2", "value2"));
     private static final Request.Method CALLBACK_METHOD = Request.Method.PUT;
     private static final Request CALLBACK_TARGET = new Request(CALLBACK_METHOD, CALLBACK_URL, CALLBACK_HEADERS);
+    private static final Request FAKE_CALLBACK_TARGET = new Request(
+            CALLBACK_METHOD,
+            URI.create("http://haha.com"),
+            CALLBACK_HEADERS);
 
     private static final BrewNVR NVR = new BrewNVR(BREW_BUILD_NAME, BREW_BUILD_VERSION, "1");
 
@@ -221,7 +225,9 @@ public class PncImportControllerTest {
         doReturn(new BrewBuild(11, NVR)).when(brewClient).findBrewBuildOfNVR(eq(NVR));
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        // also check if positiveCallback object is used instead of the callback object
+        importController
+                .importMilestone(milestoneId, CALLBACK_TARGET, null, FAKE_CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         verifySuccess();
@@ -248,7 +254,8 @@ public class PncImportControllerTest {
                 .importBuild(eq(NVR), eq(buildId), same(KOJI_IMPORT), same(IMPORT_FILE_GENERATOR));
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        // also check if callback object is used when positiveCallback is null and result is success
+        importController.importMilestone(milestoneId, null, null, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         verifySuccess();
@@ -267,7 +274,8 @@ public class PncImportControllerTest {
         doThrow(new RuntimeException(exceptionMessage)).when(pncClient).findBuildsOfProductMilestone(eq(milestoneId));
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        importController
+                .importMilestone(milestoneId, null, CALLBACK_TARGET, FAKE_CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         MilestoneReleaseResultRest result = verifyError(true);
@@ -290,7 +298,8 @@ public class PncImportControllerTest {
         doReturn(buildRecords).when(pncClient).findBuildsOfProductMilestone(eq(milestoneId));
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        importController
+                .importMilestone(milestoneId, null, CALLBACK_TARGET, FAKE_CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         verifyFailure();
@@ -311,7 +320,8 @@ public class PncImportControllerTest {
         doThrow(new CausewayException(exceptionMessage)).when(brewClient).findBrewBuildOfNVR(eq(NVR));
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        importController
+                .importMilestone(milestoneId, null, CALLBACK_TARGET, FAKE_CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         MilestoneReleaseResultRest result = verifyError(false);
@@ -348,7 +358,8 @@ public class PncImportControllerTest {
                 .importBuild(eq(NVR), eq(buildId), same(KOJI_IMPORT), same(IMPORT_FILE_GENERATOR));
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        importController
+                .importMilestone(milestoneId, null, CALLBACK_TARGET, FAKE_CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         MilestoneReleaseResultRest result = verifyCallback(ReleaseStatus.IMPORT_ERROR, true);
@@ -370,7 +381,8 @@ public class PncImportControllerTest {
         doReturn(false).when(brewClient).tagsExists(TAG_PREFIX);
 
         // Run import
-        importController.importMilestone(milestoneId, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
+        // Also test if when positive and negative callback are not set, the regular callback object is used
+        importController.importMilestone(milestoneId, null, null, CALLBACK_TARGET, CALLBACK_ID, USERNAME);
 
         // Verify
         MilestoneReleaseResultRest result = verifyFailure();

--- a/rest/src/main/java/org/jboss/pnc/causeway/rest/BrewPushMilestone.java
+++ b/rest/src/main/java/org/jboss/pnc/causeway/rest/BrewPushMilestone.java
@@ -35,6 +35,14 @@ public class BrewPushMilestone {
     @JsonUnwrapped
     @NonNull
     private MilestoneReleaseRest content;
-    @NonNull
+
+    /**
+     * Prefer using positiveCallback or negativeCallback if specified when sending back the results. Otherwise use the
+     * callback request.
+     */
     private Request callback;
+
+    private Request positiveCallback;
+
+    private Request negativeCallback;
 }

--- a/web/src/main/java/org/jboss/pnc/causeway/rest/PncImportResourceEndpoint.java
+++ b/web/src/main/java/org/jboss/pnc/causeway/rest/PncImportResourceEndpoint.java
@@ -39,10 +39,18 @@ public class PncImportResourceEndpoint implements PncImportResource {
     @WithSpan
     public BrewPushMilestoneResponse importProductMilestone(
             @SpanAttribute(value = "request") BrewPushMilestone request) {
+
+        if ((request.getPositiveCallback() == null || request.getNegativeCallback() == null)
+                && request.getCallback() == null) {
+            throw new IllegalStateException("Callbacks not specified properly");
+        }
+
         String id = UUID.randomUUID().toString();
 
         pncController.importMilestone(
                 request.getContent().getMilestoneId(),
+                request.getPositiveCallback(),
+                request.getNegativeCallback(),
                 request.getCallback(),
                 id,
                 userSerivce.getUsername());


### PR DESCRIPTION
Rex
===
Rex specifies 2 endpoints to send results:
- `positiveCallback` for positive results
- `negativeCallback` for failed / error results

Changes
=======
This commit adds support for the `/import/product/milestone` endpoint to accept in the DTO:
- `callback` Request object (as before)
- `positiveCallback` Request object
- `negativeCallback` Request object

For good result, if:
- `positiveCallback` is specified: use it to send callback result
- otherwise use the `callback` Request object

For bad result, if:
- `negativeCallback` is specified: use it to send callback result
- otherwise use the `callback` Request object

If `positiveCallback` and `negativeCallback` objects are not specified in the request, we'll default to the current behaviour of sending the callback result to the `callback` Request object. This maintains backwards compatibility.

We also refuse the request to this endpoint if:
- both `positiveCallback` and `callback` objects are null
- both `negativeCallback` and `callback` objects are null

since there'll be no way to send back the result.

### Checklist:

* [ ] Have you added unit tests for your change?
