### PR TITLE
[NCL-8808] Use userInitiator field for initial importer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <semverVersion>0.10.2</semverVersion>
     <atlasVersion>1.1.4</atlasVersion>
     <pncVersion>2.7.6</pncVersion>
-    <pncApiVersion>3.0.4</pncApiVersion>
+    <pncApiVersion>3.0.5-SNAPSHOT</pncApiVersion>
     <!-- OTEL Dependencies for Instrumentation -->
     <version.io.opentelemetry.instrumentation>1.22.0</version.io.opentelemetry.instrumentation>
     <version.com.redhat.resilience.otel>1.3.0</version.com.redhat.resilience.otel>

--- a/rest/src/main/java/org/jboss/pnc/causeway/rest/pnc/MilestoneReleaseRest.java
+++ b/rest/src/main/java/org/jboss/pnc/causeway/rest/pnc/MilestoneReleaseRest.java
@@ -30,9 +30,13 @@ import lombok.Data;
 public class MilestoneReleaseRest {
 
     private final int milestoneId;
+    private String userInitiator;
 
     @JsonCreator
-    public MilestoneReleaseRest(@JsonProperty("milestoneId") int milestoneId) {
+    public MilestoneReleaseRest(
+            @JsonProperty("milestoneId") int milestoneId,
+            @JsonProperty("userInitiator") String userInitiator) {
         this.milestoneId = milestoneId;
+        this.userInitiator = userInitiator;
     }
 }

--- a/web/src/main/java/org/jboss/pnc/causeway/rest/ImportEndpoint.java
+++ b/web/src/main/java/org/jboss/pnc/causeway/rest/ImportEndpoint.java
@@ -43,11 +43,14 @@ public class ImportEndpoint implements Import {
     @Override
     @WithSpan
     public Response importBuild(@SpanAttribute(value = "request") BuildImportRequest request) {
-        controller.importBuild(
-                request.getBuild(),
-                request.getCallback(),
-                userSerivce.getUsername(),
-                request.isReimport());
+        // Use the DTO userInitiator as the user who started the push. If this is absent, use the SSO user who did the
+        // REST request instead. They are different since the SSO user is typically just the PNC-Orch service account
+        String user = request.getUserInitiator();
+        if (user == null) {
+            user = userSerivce.getUsername();
+        }
+
+        controller.importBuild(request.getBuild(), request.getCallback(), user, request.isReimport());
         return Response.accepted().build();
     }
 

--- a/web/src/main/java/org/jboss/pnc/causeway/rest/PncImportResourceEndpoint.java
+++ b/web/src/main/java/org/jboss/pnc/causeway/rest/PncImportResourceEndpoint.java
@@ -41,11 +41,14 @@ public class PncImportResourceEndpoint implements PncImportResource {
             @SpanAttribute(value = "request") BrewPushMilestone request) {
         String id = UUID.randomUUID().toString();
 
-        pncController.importMilestone(
-                request.getContent().getMilestoneId(),
-                request.getCallback(),
-                id,
-                userSerivce.getUsername());
+        // Use the DTO userInitiator as the user who started the push. If this is absent, use the SSO user who did the
+        // REST request instead. They are different since the SSO user is typically just the PNC-Orch service account
+        String user = request.getContent().getUserInitiator();
+        if (user == null) {
+            user = userSerivce.getUsername();
+        }
+
+        pncController.importMilestone(request.getContent().getMilestoneId(), request.getCallback(), id, user);
 
         return new BrewPushMilestoneResponse(new Callback(id));
     }


### PR DESCRIPTION
When the entire PNC ecosystem switched to short-lived auth tokens, we couldn't use the user's token for brew push, from Orch to Causeway. Instead, Orch now has to use his own service account to do the brew push to Causeway.

This has the side-effect that we lose the information on who triggered the brew push. Before this commit, the "official" user is the Orch service account, which is misleading.

Instead, this commit introduces the 'userInitiator' DTO for build brew push, and for milestone brew push, to use that information as the original initiator of the brew push.

If that information is not set, we fall back to use the name of the user that did the REST request (typically the Orch service account).

### Checklist:

* [ ] Have you added unit tests for your change?
