### PR TITLE
Revert "Bump net.revelc.code.formatter:formatter-maven-plugin"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
       <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.24.1</version>
+          <version>2.11.0</version>
           <configuration>
               <configFile>../eclipse-codeStyle.xml</configFile>
           </configuration>


### PR DESCRIPTION
Reverting because it requires Java 17

This reverts commit 74ce628b01d9cee5697f34144627235e857cc324.

### Checklist:

* [ ] Have you added unit tests for your change?
