### PR TITLE
Add role allowed for endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/org/jboss/pnc/causeway/CausewayResource.java
+++ b/src/main/java/org/jboss/pnc/causeway/CausewayResource.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.pnc.causeway;
 
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
@@ -52,6 +53,7 @@ public class CausewayResource implements Causeway {
 
     @Override
     @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed({ "pnc-app-causeway-user" })
     public void importBuild(@Valid BuildPushRequest buildPushRequest) {
         HeartbeatConfig heartbeatConf = buildPushRequest.getHeartbeat();
         if (heartbeatConf != null) {
@@ -106,6 +108,7 @@ public class CausewayResource implements Causeway {
     }
 
     @Override
+    @RolesAllowed({ "pnc-app-causeway-user" })
     public void untagBuild(@Valid UntagRequest request) {
         controller.untagBuild(request.getBuild().getBrewBuildId(), request.getBuild().getTagPrefix());
     }


### PR DESCRIPTION
This is needed for authentication and authorization for the causeway endpoints.

We require that authenticated users need to have the correct role (pnc-app-causeway-users) to be able to use the brew tag and un-tag endpoints.

### Checklist:

* [ ] Have you added unit tests for your change?
