### PR TITLE
Activate kafka again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,12 @@
             <groupId>com.redhat.red.build</groupId>
             <artifactId>kojiji</artifactId>
             <version>2.22</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.22.1</quarkus.platform.version>
         <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+        <quarkus-logging-kafka.version>1.0.6</quarkus-logging-kafka.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
         <version.javadoc.plugin>3.11.2</version.javadoc.plugin>
@@ -256,6 +257,18 @@
                     <artifactId>pnc-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- logging to kafka -->
+            <groupId>org.jboss.pnc.logging</groupId>
+            <artifactId>quarkus-logging-kafka</artifactId>
+            <version>${quarkus-logging-kafka.version}</version>
+        </dependency>
+        <dependency>
+            <!-- logging to kafka -->
+            <groupId>org.jboss.pnc.logging</groupId>
+            <artifactId>quarkus-logging-kafka-deployment</artifactId>
+            <version>${quarkus-logging-kafka.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,19 @@
 
 # I believe I need to add this so tha the extension is activated at runtime?
 quarkus:
+  log:
+    handler:
+      kafka:
+        enabled: ${KAFKA_LOG_ENABLED:false}
+        broker-list: ${KAFKA_LOG_SERVER:kafka.example.com:443}
+        topic: ${KAFKA_LOG_TOPIC:kafka-topic}
+        security-protocol: SASL_SSL
+        sasl-mechanism: SCRAM-SHA-512
+        sasl-jaas-conf: "${sasl_jaas_conf}"
+        filter-logger-name-pattern: ${KAFKA_LOG_FILTER:org.jboss.pnc.*}
+        level: INFO
+        # set this to empty because default config set the wrong path
+        ssl-truststore-location: ""
   oidc:
     auth-server-url: https://keycloak-host/auth/realms/myrealm
     client-id: client


### PR DESCRIPTION
Exclude log4j-over-slf4j also!

This dependency includes an old version of the `AppenderSkeleton` class
which does not implement the `Appender` interface. This in turn messes
up with the quarkus-logging-kafka when loading classes, and we get weird
CastClassExceptions.

Excluding it fixes everything. EVERYTHING.

Documented on the quarkus-logging-kafka side here: https://github.com/project-ncl/quarkus-logging-kafka/pull/111

### Checklist:

* [ ] Have you added unit tests for your change?
