### PR TITLE
Fix deleted build reimport

### DIFF
--- a/src/main/java/org/jboss/pnc/causeway/ctl/ImportControllerImpl.java
+++ b/src/main/java/org/jboss/pnc/causeway/ctl/ImportControllerImpl.java
@@ -119,7 +119,8 @@ public class ImportControllerImpl implements ImportController {
         } else {
             if (reimport) {
                 int revision = 1;
-                while (brewBuild != null && brewClient.isBuildTagged(tagPrefix, brewBuild)) {
+                while (brewBuild != null && brewClient.isBuildTagged(tagPrefix, brewBuild)
+                        || brewClient.isBuildDeleted(brewBuild)) {
                     nvr = getNVR(nvr, ++revision);
                     brewBuild = brewClient.findBrewBuildOfNVR(nvr);
                 }


### PR DESCRIPTION
This was already fixed by @janinko but probably got lost during merging 4.0 branch into master (https://github.com/project-ncl/causeway/pull/333)
