### PR TITLE
fix verbose logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,15 @@
 
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+
+    <repository>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,25 @@
         <groupId>org.commonjava.atlas</groupId>
         <artifactId>atlas-identities</artifactId>
         <version>${atlas.version}</version>
+        <exclusions>
+          <!-- collides with Quarkus native logging -->
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.commonjava.atlas</groupId>
         <artifactId>atlas-npm-identities</artifactId>
         <version>${atlas.version}</version>
+        <exclusions>
+          <!-- collides with Quarkus native logging -->
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -100,6 +114,11 @@
       <artifactId>kojiji</artifactId>
       <version>2.25</version>
       <exclusions>
+        <!-- collides with Quarkus native logging -->
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>log4j-over-slf4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -294,17 +294,6 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <id>jboss-snapshots</id>
-      <url>https://repository.jboss.org/nexus/content/repositories/snapshots</url>
-    </repository>
-
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
       <id>central-portal-snapshots</id>
       <name>Central Portal Snapshots</name>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>


### PR DESCRIPTION
Basically, the deployment had 2 logging implementations. Logback printed everything at DEBUG level by default.
### Checklist:

* [ ] Have you added unit tests for your change?
