### PR TITLE
Update bouncycastle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <connection>scm:git:http://github.com/project-ncl/causeway.git</connection>
     <developerConnection>scm:git:git@github.com:project-ncl/causeway.git</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/project-ncl/causeway</url>
+    <url>https://github.com/project-ncl/causeway</url>
   </scm>
 
   <properties>
@@ -58,7 +58,7 @@
     <version.javadoc.plugin>3.12.0</version.javadoc.plugin>
     <version.source.plugin>3.4.0</version.source.plugin>
     <atlas.version>1.2.2</atlas.version>
-    <bouncycastle.version>1.82</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <tagSuffix/>
   </properties>
 
@@ -97,12 +97,12 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This matches the groupId:artifactId provided by Quarkus bom but updates it from 1.83 to 1.84 to avoid a CVE