### PR TITLE
Add quarkus-rest-client-jackson to fix classnotfoundexception error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
       <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
+      <!-- provides the MicroProfile REST Client used by org.jboss.pnc:rest-client -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>


### PR DESCRIPTION
It supplies org.eclipse.microprofile.rest.client.RestClientBuilder (MicroProfile REST Client) used by org.jboss.pnc:rest-client's ClientBase.createProxy since 3.5.x; rest-client no longer bundles a client runtime transitively

### Checklist:

* [ ] Have you added unit tests for your change?
